### PR TITLE
Binding `click` on a node does not work in webkit browsers

### DIFF
--- a/js/dracula_graph.js
+++ b/js/dracula_graph.js
@@ -163,7 +163,7 @@ Graph.Renderer.Raphael = function(element, graph, width, height) {
         this.dx = e.clientX;
         this.dy = e.clientY;
         selfRef.isDrag = this;
-        this.set && this.set.animate({"fill-opacity": .1}, 200) && this.set.toFront();
+        this.set && this.set.animate({"fill-opacity": .1}, 200);
         e.preventDefault && e.preventDefault();
     };
     


### PR DESCRIPTION
It seems the issue is with the call to Raphael's `Element#toFront()`: if a click() event is bound on a node with it it will only work (in webkit browsers) during double clicks. If this call is removed, clicks will work correctly.

OS: OSX 10.6.8
Browsers: Safari 5.1, Webkit trunk, Chrome 14
