### PR TITLE
validates connection present for edge

### DIFF
--- a/lib/dracula_graph.js
+++ b/lib/dracula_graph.js
@@ -117,13 +117,13 @@ Graph.Node = function DraculaNode(id, node){
     this.hidden = true;
     this.shape && this.shape.hide(); /* FIXME this is representation specific code and should be elsewhere */
     for(i in this.edges)
-      (this.edges[i].source.id == id || this.edges[i].target == id) && this.edges[i].hide && this.edges[i].hide();
+      (this.edges[i].source.id == id || this.edges[i].target == id) && this.edges[i].connection && this.edges[i].hide && this.edges[i].hide();
   };
   node.show = function() {
     this.hidden = false;
     this.shape && this.shape.show();
     for(i in this.edges)
-      (this.edges[i].source.id == id || this.edges[i].target == id) && this.edges[i].show && this.edges[i].show();
+      (this.edges[i].source.id == id || this.edges[i].target == id) && this.edges[i].connection && this.edges[i].show && this.edges[i].show();
   };
   return node;
 };


### PR DESCRIPTION
Sometimes connection is undefined at show/hide Edge functions which creates a crash for 'fg' in next code:
```javascript
AbstractEdge.prototype = {
    hide: function() {
      this.connection.fg.hide();
      this.connection.bg && this.bg.connection.hide();
    }
};
```

So I believe it is good idea to check for:
```
this.connection