### PR TITLE
Prefer explicitly set node id

### DIFF
--- a/lib/dracula_graph.js
+++ b/lib/dracula_graph.js
@@ -173,7 +173,7 @@ Dracula.Renderer.defaultRenderFunc = function(r, node) {
     "stroke-width": 2
   });
   /* set DOM node ID */
-  ellipse.node.id = node.label || node.id;
+  ellipse.node.id = node.id || node.label;
   shape = r.set().push(ellipse).push(r.text(0, 30, node.label || node.id));
   return shape;
 };


### PR DESCRIPTION
The explicitly set node id should be prefered over the label.
