### PR TITLE
Small fix for arrows.

### DIFF
--- a/src/dracula.js
+++ b/src/dracula.js
@@ -60,6 +60,7 @@ export default class Dracula {
     const target = this.addNode(targetNode)
     const style = opts.style || opts
     const edge = { style, source, target }
+    if (opts.directed) style.directed = opts.directed
     this.edges.push(edge)
     source.edges.push(edge)
     target.edges.push(edge)


### PR DESCRIPTION
The example in the documentation does't display directed arrows. Doesn't work:
g.addEdge("Banana", "Tomato", {
  directed: true,
  style: { label: "1" },
});
But it works:
g.addEdge("Mushroom", "Tomato", {
  directed: true,
});
g.addEdge("Banana", "Tomato", {
  style: { label: "1", directed: true },
});